### PR TITLE
Removing "dossierBehandelaar" emails from bcc only on "Omzendbrief"

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -27,7 +27,7 @@ def construct_needs_mail_query(message_graph_pattern_start, message_graph_patter
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-    SELECT DISTINCT ?bericht ?van ?naar ?bestuurseenheidnaam ?ontvangen ?dossiernummer ?conversatieuuid ?betreft ?mailadres ?emailBehandelaar
+    SELECT DISTINCT ?bericht ?van ?naar ?bestuurseenheidnaam ?ontvangen ?dossiernummer ?conversatieuuid ?betreft ?mailadres ?emailBehandelaar ?typecommunicatie
     WHERE {{
         GRAPH ?i {{
             ?naar a besluit:Bestuurseenheid;

--- a/tasks.py
+++ b/tasks.py
@@ -59,8 +59,9 @@ def process_send_notifications():
         if BCC_EMAIL_ADDRESSES:
             bcc_adresses = BCC_EMAIL_ADDRESSES.split(',')
 
-        if bericht.get('emailBehandelaar', {}).get('value'):
-            bcc_adresses.append(bericht.get('emailBehandelaar', {}).get('value'))
+        if bericht.get('typecommunicatie').get('value') != "Omzendbrief":
+            if bericht.get('emailBehandelaar', {}).get('value'):
+                bcc_adresses.append(bericht.get('emailBehandelaar', {}).get('value'))
 
         email['bcc'] = ','.join([addr for addr in bcc_adresses if addr])
 

--- a/tasks.py
+++ b/tasks.py
@@ -59,7 +59,9 @@ def process_send_notifications():
         if BCC_EMAIL_ADDRESSES:
             bcc_adresses = BCC_EMAIL_ADDRESSES.split(',')
 
-        if bericht.get('typecommunicatie').get('value') != "Omzendbrief":
+        type_communicatie = bericht.get('typecommunicatie').get('value')
+        
+        if type_communicatie.casefold() != "Omzendbrief".casefold():
             if bericht.get('emailBehandelaar', {}).get('value'):
                 bcc_adresses.append(bericht.get('emailBehandelaar', {}).get('value'))
 


### PR DESCRIPTION
# Description

DL-5629
(DL-5748) Bug

This PR updates the query `construct_needs_mail_query` to extract the typecommunicatie and use it to not append "dossierbehandelaar" emails in bcc when "Omzendbrief" (mass mailing)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

- To be tested

# What to check

- N/A

# Links to other PR's

- 

# Notes

- Make a Release