### PR TITLE
Get `?typecommunicatie` from correct predicate. DL-5775

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -42,7 +42,8 @@ def construct_needs_mail_query(message_graph_pattern_start, message_graph_patter
             ?bericht a schema:Message;
                 schema:dateReceived ?ontvangen;
                 schema:sender ?van;
-                schema:recipient ?naar.
+                schema:recipient ?naar;
+                <http://purl.org/dc/terms/type> ?typecommunicatie.
 
             OPTIONAL {{
               ?bericht ext:heeftBehandelaar ?behandelaar.
@@ -53,7 +54,6 @@ def construct_needs_mail_query(message_graph_pattern_start, message_graph_patter
                 <http://mu.semte.ch/vocabularies/core/uuid> ?conversatieuuid;
                 schema:identifier ?dossiernummer;
                 schema:about ?betreft;
-                #<http://purl.org/dc/terms/type> ?typecommunicatie;
                 #schema:processingTime ?reactietermijn;
                 schema:hasPart ?bericht.
 


### PR DESCRIPTION
Can you have a double look? Do my assumption stand, will this predicate always be available in the DB? I checked `berichtencentrum-sync-with-kalliope` but maybe it's worth you do a double check.
