### PR TITLE
Chore/upgrade python template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mikidi/mu-python-template:python3-port
+FROM semtech/mu-python-template:2.0.0-beta.3
 LABEL maintainer="info@redpencil.io"
 
 ENV MU_APPLICATION_GRAPH "http://mu.semte.ch/graphs/public"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-apscheduler
-pybars3
-pytz
+APScheduler==3.11.0
+pybars3==0.9.7
+pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 apscheduler
 pybars3
+pytz


### PR DESCRIPTION
After having merged [PR #9](https://github.com/lblod/berichtencentrum-email-notification-service/pull/9) and built the version, some dependencies likely got updated as well, and we encountered problems since the dependencies are not pinned. This PR updates to the latest version of the mu-python template, adds the new missing dependencies (since some were imported implicitly), and pins the requirements as much as possible.

FYI @kikef98 